### PR TITLE
跟随主线，去掉线程,以减少内存占用

### DIFF
--- a/Makefile.openssl
+++ b/Makefile.openssl
@@ -5,7 +5,7 @@ CXXFLAGS=-fexceptions -DOPENSSL=1 -O2
 LIBS=sendmsg.o openssldl.o cJSON.o nonblocking.o sslbio.o ngrok.o main.o
 all:: ngrokc $(LIBS)
 ngrokc: $(LIBS)
-	$(CXX) -s $(LIBS) -o ngrokc -lpthread -lssl -lcrypto -ldl
+	$(CXX) -s $(LIBS) -o ngrokc -lssl -lcrypto -ldl
 sendmsg.o: sendmsg.h
 openssldl.o: openssldl.h
 cJSON.o: cJSON.h


### PR DESCRIPTION
跟随主线更新，去掉openwrt-openssl里编译的-lpthread参数，不知道对性能什么的有什么影响，本人编译后使用没什么异常，每个进程内存占用3%