### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ ngrokc.exe -SER[Shost:tunnel.mobi,Sport:44433] -AddTun[Type:http,Lhost:127.0.0.1
 
 ## 2015/12/20
 - 关闭。。tcp缓存区。。以修复http连接，保存失败问题。
-- 打开tcp keeplive避免死链问题。
+- 打开tcp keepalive避免死链问题。
 - 这个版本相对完善，没啥，大问题了。。不更新了。
 
 ## 2015/12/30
@@ -201,7 +201,7 @@ ngrokc.exe -SER[Shost:tunnel.mobi,Sport:44433] -AddTun[Type:http,Lhost:127.0.0.1
   
 ### 关于编译对应路由的版本的ngrokc。
 ## 一。去http://downloads.openwrt.org/下载你路由对应的SDK版本 ，如OpenWrt-SDK-ar71xx-for-linux-x86_64-gcc-4.8-linaro_uClibc-0.9.33.2.tar.bz2，并且解压。
-## 二.需要先编译polarssl或者opnessl库（取决你想用啥库,2选1）。
+## 二.需要先编译polarssl或者openssl库（取决你想用啥库,2选1）。
 - 1.编译polarssl库
     - 去https://tls.mbed.org/download-archive下载，polarssl版本，然后解压
     - 再把buildlib.sh复制进去，并且修改export STAGING_DIR export PATH,把里面的路径改成你下载的SDK，所在的目录，注意是staging_dir目录对应STAGING_DIR，bin目录对应PATH。


### PR DESCRIPTION
There are small typos in:
- README.md

Fixes:
- Should read `openssl` rather than `opnessl`.
- Should read `keepalive` rather than `keeplive`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md